### PR TITLE
Rabbitmq support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ example/events.xml
 src/Sim-Diasca_Smart_City_Integration_Test*
 interscsimulator.conf
 output/*
+lib/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-*.beam
-*.trace
-*.swp
-*.sdar
+src/*.beam
+src/*.trace
+src/*.swp
+src/*.sdar
 src/erl_crash.dump
 example/events.xml
 src/Sim-Diasca_Smart_City_Integration_Test*
 interscsimulator.conf
 output/*
-lib/*
+deps/*

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 It is the official repository of the InterSCSimulator, a large-scale, smart city simulator. InterSCSimulator is based on Sim-Diasca, an general purpose simulator implemented in Erlang.
 
+# Dependencies
+
+To install dependencies you just need to run the `install-deps.sh` script. All
+the dependencies will be placed in the `lib/` directory.
+
+`$ ./install-deps.sh`
+
 # Configuration
 
 To run the simulator you need to create a configuration file in the root

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script will install the dependencies needed by the InterSCSimulator.
+
+DEPENDENCIES_DIR='deps'
+ROOT_DIR=`pwd`
+RABBITMQ_URL='https://www.rabbitmq.com/releases/rabbitmq-erlang-client'
+RABBITMQ_VERSION='3.6.11'
+
+if [[ ! -e $DEPENDENCIES_DIR ]]; then
+	mkdir -p $DEPENDENCIES_DIR
+	cd $DEPENDENCIES_DIR
+else
+	echo "You already have the _build directory, if you want to reinstall it,"
+	echo "please, remove it before run this script!"
+	exit -5
+fi
+
+wget "$RABBITMQ_URL/v$RABBITMQ_VERSION/rabbit_common-$RABBITMQ_VERSION.ez" 2> /dev/null
+wget "$RABBITMQ_URL/v$RABBITMQ_VERSION/amqp_client-$RABBITMQ_VERSION.ez" 2> /dev/null
+
+if [[ $? != 0 ]]; then
+	echo "Error during the download of .ez files!"
+	exit -1
+else
+	echo "I: .ez files were downloaded"
+fi
+
+unzip -q "rabbit_common-$RABBITMQ_VERSION.ez"
+unzip -q "amqp_client-$RABBITMQ_VERSION.ez"
+
+if [[ $? != 0 ]]; then
+	echo "Error during the descompress of .ez files!"
+	exit -2
+else
+	echo "I: .ez files were descompressed"
+fi
+
+ln -s "amqp_client-$RABBITMQ_VERSION" amqp_client
+cd amqp_client/include
+ln -s "../../rabbit_common-$RABBITMQ_VERSION" rabbit_common
+
+if [[ $? != 0 ]]; then
+	echo "Error during the linkage!"
+	exit -3
+else
+	echo "I: dependencies was linked"
+fi
+
+cd $ROOT_DIR

--- a/src/class_Log.erl
+++ b/src/class_Log.erl
@@ -1,20 +1,22 @@
 -module(class_Log).
 
+-include_lib("../deps/amqp_client/include/amqp_client.hrl").
+
 % Determines what are the mother classes of this class (if any):
 -define( wooper_superclasses, [ class_Actor ] ).
 
 % parameters taken by the constructor ('construct').
--define( wooper_construct_parameters, ActorSettings, LogName ).
+-define( wooper_construct_parameters, ActorSettings, LogName , Paths ).
 
 % Declaring all variations of WOOPER-defined standard life-cycle operations:
 % (template pasted, just two replacements performed to update arities)
--define( wooper_construct_export, new/2, new_link/2,
-		 synchronous_new/2, synchronous_new_link/2,
-		 synchronous_timed_new/2, synchronous_timed_new_link/2,
-		 remote_new/3, remote_new_link/3, remote_synchronous_new/3,
-		 remote_synchronous_new_link/3, remote_synchronisable_new_link/3,
-		 remote_synchronous_timed_new/3, remote_synchronous_timed_new_link/3,
-		 construct/3, destruct/1 ).
+-define( wooper_construct_export, new/3, new_link/3,
+		 synchronous_new/3, synchronous_new_link/3,
+		 synchronous_timed_new/3, synchronous_timed_new_link/3,
+		 remote_new/4, remote_new_link/4, remote_synchronous_new/4,
+		 remote_synchronous_new_link/4, remote_synchronisable_new_link/4,
+		 remote_synchronous_timed_new/4, remote_synchronous_timed_new_link/4,
+		 construct/4, destruct/1 ).
 
 % Method declarations.
 -define( wooper_method_export, actSpontaneous/1, onFirstDiasca/2, receive_action/3).
@@ -29,8 +31,24 @@
 
 % Creates a new log actor
 -spec construct( wooper:state(), class_Actor:actor_settings(),
-				class_Actor:name() ) -> wooper:state().
+				class_Actor:name() , parameter() ) -> wooper:state().
 construct( State, ?wooper_construct_parameters ) ->
+
+    code:add_pathsa( Paths ),
+
+	{ ok, Connection } = amqp_connection:start( #amqp_params_network{} ),
+	{ ok, Channel } = amqp_connection:open_channel( Connection ),
+
+	Exchange = #'exchange.declare'{ exchange = <<"simulator_exchange">>,
+                                    type = <<"topic">> },
+	#'exchange.declare_ok'{} = amqp_channel:call( Channel, Exchange ),
+
+	Publish = #'basic.publish'{ exchange = <<"simulator_exchange">>,
+                                routing_key = <<"log_output">> },
+
+	amqp_channel:cast( Channel,
+					   Publish,
+					   #amqp_msg{ payload = <<"<events version=\"1.0\">\n">> }),
 
 	ActorState = class_Actor:construct( State, ActorSettings, LogName ),
 
@@ -40,7 +58,12 @@ construct( State, ?wooper_construct_parameters ) ->
 	file_utils:write( InitFile, "<events version=\"1.0\">\n" ),
 
 	setAttributes( ActorState, [
-								{ file , InitFile } ] ).
+			{ file , InitFile },
+			{ channel, Channel },
+			{ exchange, Exchange },
+			{ publish, Publish },
+			{ connection, Connection }
+		] ).
 
 % The destructor just close the log file.
 %
@@ -48,9 +71,21 @@ construct( State, ?wooper_construct_parameters ) ->
 destruct( State ) ->
 
 	InitFile = ?getAttr(file),
+	Connection = ?getAttr(connection),
+	Channel = ?getAttr(channel),
+	Publish = ?getAttr(publish),
+	Exchange = ?getAttr(exchange),
+
+	#'exchange.declare_ok'{} = amqp_channel:call( Channel, Exchange ),
+
+	amqp_channel:cast( Channel,
+                       Publish,
+                       #amqp_msg{ payload = <<"</events>">> } ),
+
+	ok = amqp_channel:close(Channel),
+	ok = amqp_connection:close(Connection),
 
 	file_utils:write( InitFile, "</events>" ),
-
 	file_utils:close( InitFile ),
 
 	State.
@@ -65,8 +100,16 @@ actSpontaneous( State ) ->
 receive_action( State , Data , _Pid ) ->
 
 	InitFile = ?getAttr(file),
+	Channel = ?getAttr(channel),
+	Publish = ?getAttr(publish),
 
-	file_utils:write( InitFile, element( 1 , Data ) ),
+	Content = element( 1, Data ),
+
+	amqp_channel:cast( Channel,
+                       Publish,
+                       #amqp_msg{ payload = list_to_binary( Content ) }),
+
+	file_utils:write( InitFile, Content ),
 
 	?wooper_return_state_only( State ).
 

--- a/src/smart_city_test.erl
+++ b/src/smart_city_test.erl
@@ -195,9 +195,15 @@ run() ->
 
 	{ _ , Pwd } = file:get_cwd(),
 	OutputPath = string:concat( Pwd, "/" ),
+	AmqpClientPath = string:concat( Pwd, "/../deps/amqp_client"),
 
 	LogPID = class_Actor:create_initial_actor( class_Log,
-											   [ string:concat( OutputPath, element( 1 , Config ) ) ] ),
+			[ string:concat( OutputPath, element( 1 , Config ) ),
+			  [ AmqpClientPath,
+				string:concat( AmqpClientPath, "/ebin" ),
+				string:concat( AmqpClientPath, "/include/rabbit_common/ebin" )
+			  ]
+			] ),
 
 	Names = [ "car1" , "car2" , "car3" , "car4" , "car5" , "car6" ],
 


### PR DESCRIPTION
You can check this feature working after the installation of `bunny` gem and run the following ruby script:

Obs.: you need to run the rabbitmq-server service before

```
require "bunny"

STDOUT.sync = true

conn = Bunny.new("amqp://guest:guest@localhost:5672")
conn.start

ch  = conn.create_channel
x   = ch.topic("simulator_exchange")
q   = ch.queue("test", :exclusive => false)

q.bind(x, :routing_key => "#")

puts " [*] Waiting for logs. To exit press CTRL+C"

begin
  q.subscribe(:block => true) do |delivery_info, properties, body|
	puts body
  end
rescue Interrupt => _
  ch.close
  conn.close
end
```

Run the script above and then run the simulator. All the xml output will be printed in your terminal :)